### PR TITLE
셀러 계정 관리 페이지에서 해당 셀러의 상세 데이터 반환 api 구현

### DIFF
--- a/controller/user_controller.py
+++ b/controller/user_controller.py
@@ -7,7 +7,6 @@ def create_user_endpoints(services, Session):
     user_service = services
     user_bp = Blueprint('user', __name__, url_prefix = '/api/user')
 
-    @user_bp.route('/', methods = ['GET'])
     """
     Args:
         services : service.py 연결
@@ -19,6 +18,7 @@ def create_user_endpoints(services, Session):
     History;
         2020-09-21 (hj885353@gmail.com) : 초기 생성
     """
+    @user_bp.route('/', methods = ['GET'])
     def user_info():
         try:
             session = Session()

--- a/model/seller_dao.py
+++ b/model/seller_dao.py
@@ -1,4 +1,5 @@
 import bcrypt
+import datetime
 from flask           import jsonify
 from sqlalchemy import text
 
@@ -252,3 +253,73 @@ class SellerDao:
 
         seller_count['filtered_seller_count'] = filter_query_values_count['filtered_seller_count']
         return seller_info, seller_count
+
+    def get_seller_info(self, seller_info, session):
+        """ 계정의 셀러정보 표출
+        seller_info['parameter_seller_no']로 seller_no를 인자로 받아 해당 seller의 정보 표출
+
+        Args:
+            seller_info: seller 정보
+            (parameter_seller_no: path parameter로 받은 seller의 no)
+            session: db connection 객체
+        Returns:
+            seller_info_result (r'type : dict)
+        Authors:
+            hj885353@gmail.com (김해준)
+        History:
+            2020-09-30 (hj885353@gmail.com) : 초기 생성
+        """
+        # 인자로 받은 seller_info에섯 seller_no를 미리 정의하기 위한 dict
+        # 해당 작업을 수행하지 않을 경우 python dict cannot converted Error 발생
+        seller_no_data = {
+            'seller_no' : seller_info['parameter_seller_no']
+        }
+        # seller_info로 넘어 온 id 값을 가진 seller의 정보를 표출해 주는 쿼리문
+        seller_info_statment = """
+            SELECT
+                image_url,
+                seller_status_id,
+                seller_attribute_id,
+                korean_name,
+                eng_name,
+                seller_loginID,
+                seller_page_background_image_url,
+                simple_description,
+                detail_description,
+                m.name,
+                m.phone_number,
+                m.email,
+                service_center_phone,
+                postal_code,
+                address,
+                service_center_open_time,
+                service_center_close_time,
+                bank,
+                account_holder,
+                account_number,
+                start_at,
+                end_date,
+                modifier_id,
+                shipping_info,
+                refund_policy,
+                model_height,
+                model_top_size,
+                model_pants_size,
+                model_foots_size,
+                update_feed_message
+            FROM seller_info as si
+            INNER JOIN sellers as s ON s.id = si.seller_id
+            INNER JOIN managers as m ON m.id = si.manager_id
+            INNER JOIN seller_status as ss ON ss.id = si.seller_status_id
+            INNER JOIN seller_attributes as sa ON sa.id = si.seller_attribute_id
+            WHERE si.end_date = '9999-12-31 23:59:59'
+            AND s.id = :seller_no
+            AND si.is_deleted = 0
+            AND s.is_deleted = 0
+            AND m.is_deleted = 0
+        """
+        # tuple -> dict로 casting
+        seller_info_result = dict(session.execute(seller_info_statment, seller_no_data).fetchone())
+
+        return seller_info_result
+        

--- a/service/seller_service.py
+++ b/service/seller_service.py
@@ -108,3 +108,21 @@ class SellerService:
         """
         seller_list_result = self.seller_dao.get_seller_list(valid_param, session)
         return seller_list_result
+
+    def get_seller_info(self, seller_info, session):
+        """ 계정의 셀러정보 표출
+        controller에서 받은 seller_info를 dao의 get_seller_info 함수로 전달
+
+        Args:
+            seller_info: seller 정보
+            session: db connection 객체
+        Returns:
+            seller_info_result (r'type : dict)
+        Authors:
+            hj885353@gmail.com (김해준)
+        History:
+            2020-09-30 (hj885353@gmail.com) : 초기 생성
+        """
+        seller_info_result = self.seller_dao.get_seller_info(seller_info, session)
+
+        return seller_info_result

--- a/utils.py
+++ b/utils.py
@@ -1,26 +1,44 @@
 import jwt
 from flask import request, g, jsonify
 from config import SECRET
-from functools import wraps
 
-def login_required(func):      
-    @wraps(func)                   
-    def decorated_function(*args, **kwargs):
-        access_token = request.headers.get('Authorization') 
-        if access_token is not None:  
-            try:
-                payload = jwt.decode(access_token, SECRET['SECRET_KEY'], algorithm = SECRET['ALGORITHMS']) 
-            except jwt.InvalidTokenError:
-                 payload = None     
-
-            if payload is None:
-                return Response(status = 401)  
-
-            seller_no   = payload['seller_info']
-            g.seller_no = seller_no
+def login_required(Session):
+    def inner_function(func):
+        def wrapper(*args, **kwargs):
+            access_token = request.headers.get('Authorization', None)
+            session = Session()
             
-        else:
-            return Response(status = 401)  
+            if access_token:
+                try:
+                    payload = jwt.decode(access_token, SECRET['SECRET_KEY'], algorithm = SECRET['ALGORITHMS'])
+                    seller_no = payload['seller_info']
 
-        return func(*args, **kwargs)
-    return decorated_function
+                    if session:
+                        get_seller_info_stmt = ("""
+                            SELECT 
+                                id,
+                                is_admin,
+                                is_deleted 
+                            FROM 
+                                sellers
+                            WHERE id = :seller_no
+                        """)
+                        seller = dict(session.execute(get_seller_info_stmt, {'seller_no' : seller_no}).fetchone())
+                        if seller:
+                            if seller['is_deleted'] == 0:
+                                g.seller_info = {
+                                    'seller_no': seller_no,
+                                    'is_admin': seller['is_admin']
+                                }
+                                session.close()
+                                return func(*args, **kwargs)
+                            return jsonify({'message': 'DELETED_ACCOUNT'}), 400
+                        return jsonify({'message': 'ACCOUNT_DOES_NOT_EXIST'}), 404
+
+                except jwt.InvalidTokenError:
+                    return jsonify({'message': 'INVALID_TOKEN'}), 401
+
+                return jsonify({'message': 'NO_DATABASE_CONNECTION'}), 400
+            return jsonify({'message': 'INVALID_TOKEN'}), 401
+        return wrapper
+    return inner_function


### PR DESCRIPTION
- path parameter로 seller의 id를 받아서 해당 id의 데이터 반환
- 로그인 데코레이터에서 삭제 및 관리자의 여부까지 받을 수 있도록 수정
- 로그인 데코레이터에서 db connection 객체 받기 위해 함수를 하나 더
  덧붙여줌
- 주석 정리