### PR TITLE
셀러 정보 수정 api 구현

### DIFF
--- a/controller/seller_controller.py
+++ b/controller/seller_controller.py
@@ -227,7 +227,7 @@ def create_seller_endpoints(services, Session):
     )
     def get_seller_info(*args, **kwargs):
         """ 계정의 셀러정보 표출
-        path parameter로 seller_no 를 받고 해당 seller
+        path parameter로 seller_no 를 받고 해당 seller의 정보를 표출해 줌
 
         Args:
             seller_info: seller 정보
@@ -255,6 +255,50 @@ def create_seller_endpoints(services, Session):
             return jsonify({'message': 'NO_DATABASE_CONNECTION'}), 500
 
         except Exception as e:
+            return jsonify({'message' : f'{e}'})
+
+        finally:
+            session.close()
+
+    @seller_bp.route('/<int:parameter_seller_no>', methods=['PUT'], endpoint='change_seller_info')
+    @login_required(Session)
+    @validate_params(
+        Param('parameter_seller_no', PATH, int, required = False)
+    )
+    def change_seller_info(*args, **kwargs):
+        """
+        path parameter로 seller_id 를 받는다. 
+        client로부터 받는 request를 받는다.
+        로그인 데코레이터에서 g 객체를 사용하여 해당 seller에 대한 info를 받아 해당 데이터를 service에 전달한다.
+
+        Args:
+            validate_params 데코레이터를 통과 한 값을 인자로 받음
+        Returns:
+            INSERT SUCCESS, 200
+            DB_CONNECTION_ERROR, 500
+        Authors:
+            hj885353@gmail.com (김해준)
+        History:
+            2020-10-01 (hj885353@gmail.com) : 초기 생성
+        """
+        data = request.json
+        change_seller_info = {
+            'parameter_seller_no': args[0],
+            'seller_data'        : data,
+            'seller_info'        : g.seller_info
+        }
+
+        session = Session()
+        try:
+            if session:
+                change_seller_info_result = seller_service.change_seller_info(change_seller_info, session)
+                session.commit()
+                return jsonify({'message' : 'SUCCESS'}), 200
+
+            return jsonify({'message': 'NO_DATABASE_CONNECTION'}), 500
+
+        except Exception as e:
+            session.rollback()
             return jsonify({'message' : f'{e}'})
 
         finally:

--- a/service/seller_service.py
+++ b/service/seller_service.py
@@ -126,3 +126,19 @@ class SellerService:
         seller_info_result = self.seller_dao.get_seller_info(seller_info, session)
 
         return seller_info_result
+
+    def change_seller_info(self, seller_info_data, session):
+        """
+        endpoint로부터 전달 받은 seller에 대한 data를 dao로 전달시키는 함수입니다.
+
+        Args:
+            seller_info_data: endpoint에서 전달받은 seller에 대한 정보
+            session: db connection 객체
+        Returns:
+
+        Authors:
+            hj885353@gmail.com (김해준)
+        History:
+            2020-10-01 (hj885353@gmail.com) : 초기 생성
+        """
+        change_seller_info_result = self.seller_dao.change_seller_info(seller_info_data, session)

--- a/utils.py
+++ b/utils.py
@@ -16,19 +16,22 @@ def login_required(Session):
                     if session:
                         get_seller_info_stmt = ("""
                             SELECT 
-                                id,
-                                is_admin,
-                                is_deleted 
+                                s.id,
+                                s.is_admin,
+                                s.is_deleted,
+                                si.manager_id
                             FROM 
-                                sellers
-                            WHERE id = :seller_no
+                                sellers as s
+                            INNER JOIN seller_info as si ON si.seller_id = s.id
+                            WHERE s.id = :seller_no
                         """)
                         seller = dict(session.execute(get_seller_info_stmt, {'seller_no' : seller_no}).fetchone())
                         if seller:
                             if seller['is_deleted'] == 0:
                                 g.seller_info = {
                                     'seller_no': seller_no,
-                                    'is_admin': seller['is_admin']
+                                    'is_admin': seller['is_admin'],
+                                    'manager_id' : seller['manager_id']
                                 }
                                 session.close()
                                 return func(*args, **kwargs)


### PR DESCRIPTION
- 셀러 정보 수정에 대해서 선분 이력으로 관리 할 수 있도록 api 구현
- 종료 된 이력의 종료 시점과 새로운 이력의 시작 시간이 갖도록 구현
- 종료 된 이력에 대해서는 soft_delete 처리
- login decorator에서 manager_id도 받아올 수 있도록 수정