### PR TITLE
[셀러 계정 관리] 내림차순 정렬, 페이지네이션 default값 설정

### DIFF
--- a/controller/seller_controller.py
+++ b/controller/seller_controller.py
@@ -170,6 +170,10 @@ def create_seller_endpoints(services, Session):
             hj885353@gmail.com
         History:
             2020-09-28 (hj885353@gmail.com): 초기 생성
+            2020-10-13 (hj885353@gmail.com): 페이지네이션 로직 변경
+                기존 : offset, limit을 querystring으로 받아서 해당 조건만 걸어줌
+                변경 : SQL의 LIMIT과 OFFSET 기능을 사용하여 10개씩보기, 20개씩 보기 기능 추가
+                      pagenation 관련 QueryString이 입력되지 않았을때를 위한 default값 설정
         """
         start_at = args[13]
         end_date = args[14]
@@ -197,8 +201,8 @@ def create_seller_endpoints(services, Session):
         valid_param['action']           = args[12]
         valid_param['start_at']         = start_at
         valid_param['end_date']         = end_date
-        valid_param['filterLimit']      = args[15]
-        valid_param['page']             = args[16]
+        valid_param['filterLimit']      = args[15] if args[15] else 10
+        valid_param['page']             = args[16] if args[16] else 0
 
         # 유저 정보를 g에서 읽어와서 service 에 전달
         seller_info = g.seller_info

--- a/model/seller_dao.py
+++ b/model/seller_dao.py
@@ -160,7 +160,7 @@ class SellerDao:
                 변경 : SQL LIMIT, OFFSET 사용하여 10개씩 보기, 20개씩 보기 등의 로직 구현
                       마지막 페이지 번호도 Response로 보내주도록 구현
                       필터링 된 갯수만 return해주도록 변경. 
-
+            2020-10-13 (hj885353@gmail.com) : 내림차순 로직 추가
         """
         # 키워드 검색을 위한 쿼리문
         select_seller_list_statement = """
@@ -276,9 +276,9 @@ class SellerDao:
         if valid_param.get('filterLimit', None):
             if valid_param.get('page', None):
                 valid_param['offset'] = valid_param['page'] * valid_param['filterLimit']
-                select_seller_list_statement += " LIMIT :filterLimit OFFSET :offset"
+                select_seller_list_statement += " ORDER BY sellers.id DESC LIMIT :filterLimit OFFSET :offset"
             else:
-                select_seller_list_statement += " LIMIT :filterLimit"
+                select_seller_list_statement += " ORDER BY sellers.id DESC LIMIT :filterLimit"
         
         # sql 명령문에 키워드 추가가 완료되면 정렬, limit, offset 쿼리문 추가
         seller_infos = session.execute(select_seller_list_statement, valid_param).fetchall()


### PR DESCRIPTION
- 셀러 전체 리스트 반환 API에서 seller의 id값을 기준으로 내림차순
  정렬하여 Response 되도록 기능 추가
- 페이지네이션에 관련 된 QueryString이 입력되지 않았을 경우를 대비한
  default 값 설정